### PR TITLE
change regex for node/color labelling scheme in grafana dashboards

### DIFF
--- a/docker/grafana/dashboards/Erlang-Distribution.json
+++ b/docker/grafana/dashboards/Erlang-Distribution.json
@@ -533,43 +533,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -689,43 +689,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -824,43 +824,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -959,43 +959,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1092,43 +1092,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1225,43 +1225,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1360,43 +1360,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1507,43 +1507,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -2000,43 +2000,43 @@
       },
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -2140,43 +2140,43 @@
       },
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],

--- a/docker/grafana/dashboards/Erlang-Distributions-Compare.json
+++ b/docker/grafana/dashboards/Erlang-Distributions-Compare.json
@@ -190,43 +190,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],

--- a/docker/grafana/dashboards/RabbitMQ-Overview.json
+++ b/docker/grafana/dashboards/RabbitMQ-Overview.json
@@ -1205,43 +1205,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1358,43 +1358,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1512,43 +1512,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1665,43 +1665,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1833,43 +1833,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -1970,43 +1970,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -2121,43 +2121,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -2258,43 +2258,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -2395,43 +2395,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -2532,43 +2532,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -2902,43 +2902,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -3038,43 +3038,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -3191,43 +3191,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -3327,43 +3327,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -3463,43 +3463,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -3941,43 +3941,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -4077,43 +4077,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -4230,43 +4230,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -4383,43 +4383,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -4550,43 +4550,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -4686,43 +4686,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -4839,43 +4839,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -5006,43 +5006,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -5142,43 +5142,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -5296,43 +5296,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],

--- a/docker/grafana/dashboards/RabbitMQ-Quorum-Queues-Raft.json
+++ b/docker/grafana/dashboards/RabbitMQ-Quorum-Queues-Raft.json
@@ -99,43 +99,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -308,43 +308,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -447,43 +447,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],
@@ -595,43 +595,43 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "/^rabbit@\\w+0/",
+          "alias": "/^rabbit@[\\w.-]+0/",
           "color": "#56A64B"
         },
         {
-          "alias": "/^rabbit@\\w+1/",
+          "alias": "/^rabbit@[\\w.-]+1/",
           "color": "#F2CC0C"
         },
         {
-          "alias": "/^rabbit@\\w+2/",
+          "alias": "/^rabbit@[\\w.-]+2/",
           "color": "#3274D9"
         },
         {
-          "alias": "/^rabbit@\\w+3/",
+          "alias": "/^rabbit@[\\w.-]+3/",
           "color": "#A352CC"
         },
         {
-          "alias": "/^rabbit@\\w+4/",
+          "alias": "/^rabbit@[\\w.-]+4/",
           "color": "#FF780A"
         },
         {
-          "alias": "/^rabbit@\\w+5/",
+          "alias": "/^rabbit@[\\w.-]+5/",
           "color": "#96D98D"
         },
         {
-          "alias": "/^rabbit@\\w+6/",
+          "alias": "/^rabbit@[\\w.-]+6/",
           "color": "#FFEE52"
         },
         {
-          "alias": "/^rabbit@\\w+7/",
+          "alias": "/^rabbit@[\\w.-]+7/",
           "color": "#8AB8FF"
         },
         {
-          "alias": "/^rabbit@\\w+8/",
+          "alias": "/^rabbit@[\\w.-]+8/",
           "color": "#CA95E5"
         },
         {
-          "alias": "/^rabbit@\\w+9/",
+          "alias": "/^rabbit@[\\w.-]+9/",
           "color": "#FFB357"
         }
       ],


### PR DESCRIPTION
Changed the regex for node/color labelling scheme in grafana dashboards (for zero node the change was  from `^rabbit@\w+0` to `^rabbit@[\w.-]+0`) . With this change RabbitMQ nodes with names like rabbit@rabbit-1.mycluster.mynamespace have correct colors in the dashboards. This makes  node/color labelling work correctly in the deployments with similar naming scheme as is used in [RabbitMQ K8S example](https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/blob/master/examples/minikube/statefulset.yaml#L85) .

closes #33 