### PR TITLE
Prevent non-zero publisher count in Grafana when aggregating metrics

### DIFF
--- a/docker/grafana/dashboards/RabbitMQ-Overview.json
+++ b/docker/grafana/dashboards/RabbitMQ-Overview.json
@@ -296,7 +296,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(rabbitmq_channel_messages_published_total * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\"})",
+          "expr": "sum(rabbitmq_channels * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\"}) - sum(rabbitmq_channel_consumers * on(instance) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$rabbitmq_cluster\"})",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,


### PR DESCRIPTION
In the case where there are 0 channels (and as such 0 publishers), the
dashboard reports there are actually `n` publishers in an `n`-node
cluster.

## Proposed Changes

This changes the calculation of publishers to be number of
channels (which is always known) minus the number of consumers (which is
always known). This avoids the issue where there is ambiguity where a channel
which is publishing, but has not actively published _yet_.

Prior to this change, a cluster configured with `prometheus.return_per_object_metrics = false` will always report a non-zero number of publishers, even if there is no traffic on that cluster. For my example screenshots, I am using a three-node cluster with a random RabbitMQ pod being killed every minute, over the course of 5 minutes. You can see that there are always n publishers reported in Grafana for n nodes:
![image](https://user-images.githubusercontent.com/23215294/98961283-4ea9aa80-24fd-11eb-8534-376c24464c3c.png)

After this change, this is correctly reported as 0:
![image](https://user-images.githubusercontent.com/23215294/98961427-76007780-24fd-11eb-98d9-907639df3d07.png)

I confirmed that the metric behaves as usual where there are non-zero publishers using PerfTest with 5 consumers & publishers:
![image](https://user-images.githubusercontent.com/23215294/98961505-89abde00-24fd-11eb-9d06-7b418578f7a5.png)


## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [N/A?] All tests pass locally with my changes
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] I have added necessary documentation (if appropriate)
- [N/A] Any dependent changes have been merged and published in related repositories

## Further Comments

Discovered this with @gerhard while we were working on https://github.com/rabbitmq/tgir/issues/19 